### PR TITLE
Rerun publication generation to fix formatting and order errors

### DIFF
--- a/bib/progress-bib.html
+++ b/bib/progress-bib.html
@@ -2,20 +2,11 @@
 <!-- This document was automatically generated with bibtex2html 1.99
      (see http://www.lri.fr/~filliatr/bibtex2html/),
      with the following command:
- 
-     bibtex2html -s ieeetr --no-abstract --no-keywords --nodoc --nobibsource --no-keys -nodoi -noeprint -linebreak -d -r -nf webpage " <i class="fa fa-link"></i> Website " -nf talk " <i class="fas fa-chalkboard-teacher"></i> Talk  " -nf video " <i class="fa fa-play"></i> Video  " -nf url "<i class="fa fa-file-pdf"></i> PDF  " --output /home/bill/garage/progress-web/scripts/../bib/progress-bib /home/bill/garage/progress-web/scripts/../bib/progress.bib  -->
- 
+     bibtex2html -s ieeetr --no-abstract --no-keywords --nodoc --nobibsource --no-keys -nodoi -noeprint -linebreak -d -r -nf webpage " <i class="fa fa-link"></i> Website " -nf talk " <i class="fas fa-chalkboard-teacher"></i> Talk  " -nf video " <i class="fa fa-play"></i> Video  " -nf url "<i class="fa fa-file-pdf"></i> PDF  " --output /home/jana/code/progress-web/scripts/../bib/progress-bib /home/jana/code/progress-web/scripts/../bib/progress.bib  -->
 
 
 
 
- 
-<p><a name="alphonsus2020fdreplan"></a>
-
-A.&nbsp;Adu-Bredu, Z.&nbsp;Zeng, N.&nbsp;Pusalkar, and O.&nbsp;C. Jenkins, <b>Robot task planning
-  for low entropy belief states,</b> <em>arXiv preprint arXiv:2011.09105</em>, 2020.<br />
-&nbsp;<a href="https://arxiv.org/abs/2011.09105"><i class="fa fa-file-pdf"></i> PDF  </a>&nbsp;
-=======
 <p><a name="opipari2021dnbp"></a>
 
 A.&nbsp;Opipari, C.&nbsp;Chen, S.&nbsp;Wang, J.&nbsp;Pavlasek, K.&nbsp;Desingh, and O.&nbsp;C. Jenkins,
@@ -23,7 +14,15 @@ A.&nbsp;Opipari, C.&nbsp;Chen, S.&nbsp;Wang, J.&nbsp;Pavlasek, K.&nbsp;Desingh, 
   arXiv:2101.05948</em>, 2021.<br />
 &nbsp;<a href="https://arxiv.org/abs/2101.05948"><i class="fa fa-file-pdf"></i> PDF  </a>&nbsp;
 <a href="projects/dnbp"> <i class="fa fa-link"></i> Website </a>&nbsp;
- 
+
+</p>
+
+<p><a name="alphonsus2020fdreplan"></a>
+
+A.&nbsp;Adu-Bredu, Z.&nbsp;Zeng, N.&nbsp;Pusalkar, and O.&nbsp;C. Jenkins, <b>Robot task planning
+  for low entropy belief states,</b> <em>arXiv preprint arXiv:2011.09105</em>, 2020.<br />
+&nbsp;<a href="https://arxiv.org/abs/2011.09105"><i class="fa fa-file-pdf"></i> PDF  </a>&nbsp;
+
 </p>
 
 <p><a name="chen2020manipulation"></a>


### PR DESCRIPTION
FYI @alphonsusadubredu , there was a formatting error that caused your paper to appear in the wrong order and have these extra equals signs. Let me know if you think there's an issue with the script that caused that - maybe it was just from the merge.

![image](https://user-images.githubusercontent.com/7458623/105204387-1aacc000-5b12-11eb-8550-714e0ed8b652.png)
