### PR TITLE
Project page formatting update

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2131,17 +2131,62 @@ div.person header p {
 	line-height: 1em;
 }
 
-.box.post.project p {
-	padding: 0 5em;
+.project > .abstract {
+	width: 80%;
+	margin: 0 auto;
+}
+	.project > .abstract.wide {
+		width: 100%;
+	}
+
+.project > .paperlinks {
+	width: 80%;
+	margin: 0 auto;
 }
 
-.project a.paperlinks {
-	text-decoration: none;
+	.project > .paperlinks.wide {
+		width: 100%;
+	}
+
+	.project > .paperlinks p {
+		margin: 0;
+	}
+	.project > .paperlinks a {
+		text-decoration: none;
+	}
+	.project > .paperlinks a:hover {
+		color: #5d5d5d;
+	}
+
+.project-authors {
+    text-align: center;
+    margin-bottom: 2em;
 }
 
-.project a.paperlinks:hover {
-	color: #5d5d5d;
-}
+	.row.project-authors {
+		margin-top: -1em;
+		margin-left: -1em;
+	}
+
+	.row.project-authors > .project-author {
+		padding: 1em 0 0 1em;
+	}
+		.project-author p {
+			padding: 0;
+			margin-bottom: 0;
+			font-size: medium;
+		}
+		.project-author h3 {
+			padding: 0;
+			font-size: large;
+		}
+			.project-author h3 a {
+				text-decoration: underline;
+			}
+			.project-author h3 a:hover {
+				color: #FFCB05;
+				text-decoration: none;
+			}
 
 .image.pitch.centered img {
     margin: 0 auto;

--- a/projects/_template/index.html
+++ b/projects/_template/index.html
@@ -25,24 +25,72 @@
 
                     <!-- Content -->
                     <article class="box post project">
+                        <!-- TITLE -->
                         <header>
                             <h2>Paper Title</h2>
-                            <p>First Author, Second Author, Third Author...</p>
                         </header>
 
-                        <!-- Path to a pitch image. Can be removed if not needed. -->
+                        <!-- AUTHORS -->
+                        <div class="row aln-center project-authors">
+                            <!-- Add a div entry exactly as below for each author (keep all classes).
+
+                                The link belonging to the author name should point to the author's webpage. Remove the
+                                link if the author doesn't have one. The affiliation should be the institution the
+                                author belongs to, ie "University of Michigan."
+                            -->
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3><a href="#">First Author</a></h3>
+                                <p>Affiliation</p>
+                            </div>
+
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3><a href="#">Second Author</a></h3>
+                                <p>Affiliation</p>
+                            </div>
+
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3><a href="#">Third Author</a></h3>
+                                <p>Affiliation</p>
+                            </div>
+
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3><a href="#">Fourth Author</a></h3>
+                                <p>Affiliation</p>
+                            </div>
+                        </div>
+
+                        <!-- Path to a pitch image. Can be removed if not needed.
+
+                            If you have images to include on this webpage, you should make a subfolder called "images"
+                            in your project page folder. Then the (relative) path would look like: "images/MY_IMG.png".
+
+                            By default, this image will not take up the whole box, which is more aesthetic. If your
+                            pitch figure is particularly long and you need it to fill the whole horizontal space,
+                            remove the "pitch" class.
+                        -->
                         <div class="image pitch centered"><img src="../../images/headshots/fetch.jpg" alt="" /></div>
 
-                        <p>
-                            Abstract.
-                        </p>
+                        <!-- ABSTRACT -->
+                        <!-- If your pitch figure is wide and you want the abstract to match, add the class "wide" next
+                             to the class "abstract" below.-->
+                        <div class="abstract">
+                            <p>
+                                Abstract.
+                            </p>
+                        </div>
 
-                        <!-- Links. -->
-                        <p>
-                            <a href="#" class="paperlinks"><i class="far fa-file-pdf"></i> Read the Paper</a> &nbsp;&nbsp;
-                            <!-- Optional. -->
-                            <a href="#" class="paperlinks"><i class="fas fa-chalkboard-teacher"></i> Watch the Talk</a>
-                        </p>
+                        <!-- PAPER LINKS -->
+                        <!-- If your pitch figure and abstract are wide, also add the the class "wide" next to the
+                             class "paperlinks" below. Include whatever links are relevant.-->
+                        <div class="paperlinks">
+                            <p>
+                                <a href="#"><i class="far fa-file-pdf"></i>&nbsp;&nbsp;Paper</a>&nbsp;&nbsp;
+                                <!-- Optional. -->
+                                <a href="#"><i class="fas fa-chalkboard-teacher"></i>&nbsp;&nbsp;Talk</a>&nbsp;&nbsp;
+                                <a href="#"><i class="fas fa-code"></i>&nbsp;&nbsp;Code</a>&nbsp;&nbsp;
+                                <a href="#cite"><i class="fas fa-quote-right"></i>&nbsp;&nbsp;Cite</a>
+                            </p>
+                        </div>
 
                     </article>
 
@@ -60,7 +108,7 @@
                     </article>
 
                     <article class="box post">
-                        <header>
+                        <header id="cite">
                             <h2>Citation</h2>
                         </header>
 
@@ -83,7 +131,7 @@
                 <!-- Copyright -->
                 <div id="copyright">
                     <ul class="links">
-                        <li>&copy; 2020. All rights reserved.</li><li>Design: Dopetrope by
+                        <li>&copy; 2022. All rights reserved.</li><li>Design: Dopetrope by
                     <a href="http://twitter.com/ajlkn">AJ</a> for <a href="http://html5up.net/">HTML5 UP</li>
                     </ul>
                 </div>

--- a/projects/dnbp/assets/dnbp.css
+++ b/projects/dnbp/assets/dnbp.css
@@ -30,7 +30,3 @@
 .image.centered video {
   margin: 0 auto;
 }
-
-.box.post.project p {
-    padding: 0;
-}

--- a/projects/dnbp/index.html
+++ b/projects/dnbp/index.html
@@ -34,21 +34,25 @@
                         <!-- Path to a pitch image. Can be removed if not needed. -->
                         <div class="image centered"><img src="images/dnbp_pitch.jpeg" alt="" /></div>
 
-                        <p>
-                            We present a differentiable approach to learn the probabilistic factors used for inference by a nonparametric belief propagation algorithm.
-                            Existing nonparametric belief propagation methods rely on domain-specific features encoded in the probabilistic factors of a graphical model.
-                            In this work, we replace each crafted factor with a differentiable neural network enabling the factors to be learned using an efficient optimization routine from labeled data.
-                            By combining differentiable neural networks with an efficient belief propagation algorithm, our method learns to maintain a set of marginal posterior samples using end-to-end training.
-                            We evaluate our differentiable nonparametric belief propagation (DNBP) method on a set of articulated pose tracking tasks and compare performance with learned baselines.
-                            Results from these experiments demonstrate the effectiveness of using learned factors for tracking and suggest the practical advantage over hand-crafted approaches.
-                        </p>
+                        <div class="abstract wide">
+                            <p>
+                                We present a differentiable approach to learn the probabilistic factors used for inference by a nonparametric belief propagation algorithm.
+                                Existing nonparametric belief propagation methods rely on domain-specific features encoded in the probabilistic factors of a graphical model.
+                                In this work, we replace each crafted factor with a differentiable neural network enabling the factors to be learned using an efficient optimization routine from labeled data.
+                                By combining differentiable neural networks with an efficient belief propagation algorithm, our method learns to maintain a set of marginal posterior samples using end-to-end training.
+                                We evaluate our differentiable nonparametric belief propagation (DNBP) method on a set of articulated pose tracking tasks and compare performance with learned baselines.
+                                Results from these experiments demonstrate the effectiveness of using learned factors for tracking and suggest the practical advantage over hand-crafted approaches.
+                            </p>
+                        </div>
 
                         <!-- Links. -->
-                        <p>
-                            <a href="https://arxiv.org/abs/2101.05948" class="paperlinks"><i class="far fa-file-pdf"></i>&nbsp;&nbsp;Paper</a>&nbsp;&nbsp;
-                            <!-- <a href="#" class="paperlinks"><i class="fas fa-code"></i>&nbsp;&nbsp;Code</a>&nbsp;&nbsp; -->
-                            <a href="#cite" class="paperlinks"><i class="fas fa-quote-right"></i>&nbsp;&nbsp;Cite</a>
-                        </p>
+                        <div class="paperlinks wide">
+                            <p>
+                                <a href="https://arxiv.org/abs/2101.05948"><i class="far fa-file-pdf"></i>&nbsp;&nbsp;Paper</a>&nbsp;&nbsp;
+                                <!-- <a href="#"><i class="fas fa-code"></i>&nbsp;&nbsp;Code</a>&nbsp;&nbsp; -->
+                                <a href="#cite"><i class="fas fa-quote-right"></i>&nbsp;&nbsp;Cite</a>
+                            </p>
+                        </div>
 
                     </article>
 
@@ -361,7 +365,7 @@
                 <!-- Copyright -->
                 <div id="copyright">
                     <ul class="links">
-                        <li>&copy; 2020. All rights reserved.</li><li>Design: Dopetrope by
+                        <li>&copy; 2022. All rights reserved.</li><li>Design: Dopetrope by
                     <a href="http://twitter.com/ajlkn">AJ</a> for <a href="http://html5up.net/">HTML5 UP</li>
                     </ul>
                 </div>

--- a/projects/narf/index.html
+++ b/projects/narf/index.html
@@ -25,30 +25,51 @@
 
                     <!-- Content -->
                     <article class="box post project">
+                        <!-- TITLE -->
                         <header>
                             <h2>NARF: Neural Articulated Radiance Fields for Configuration-Aware Rendering</h2>
-                            <p>Stanley Lewis, Jana Pavlasek, Odest Chadwicke Jenkins</p>
                         </header>
+
+                        <!-- AUTHORS -->
+                        <div class="row aln-center project-authors">
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3>Stanley Lewis</h3>
+                                <p>University of Michigan</p>
+                            </div>
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3><a href="http://janapavlasek.com/">Jana Pavlasek</a></h3>
+                                <p>University of Michigan</p>
+                            </div>
+                            <div class="col-3 col-4-large col-4-medium col-6-small project-author">
+                                <h3><a href="https://web.eecs.umich.edu/~ocj/">Odest Chadwicke Jenkins</a></h3>
+                                <p>University of Michigan</p>
+                            </div>
+                        </div>
 
                         <!-- Pitch image. -->
                         <div class="image pitch centered"><img src="images/pitch.png" alt="" /></div>
 
-                        <p>
-                            Articulated objects pose a unique challenge for robotic perception and manipulation.
-                            Their larger number of degrees-of-freedom makes localization and other tasks more computationaly difficult, while also making the process of real-world dataset collection unscalable.
-                            With the aim of introducing a tool to address these scalability issues, we propose Neural Articulated Radiance Fields (NARF): a pipeline which uses a fully-differentiable, configuration parameterized Neural Radiance Field (NeRF) as a means of providing high quality renderings of articulated objects.
-                            NARF requires no explicit knowledge of the object structure at inference time.
-                            We propose a parts-based training mechanism which allows for creating object rendering models that generalize well across the configuration space even if the underlying training data has as few as one configuration represented.
-                            We demonstrate the usefulness of this approach by training configurable renderers on a real-world articulated tool data collected via a Fetch Mobile Manipulator robot.
-                            We then show the applicability of the model to generative or gradient-descent based inference methods by extracting configuration estimates and fine tuning object pose from an initial standard 6 degree-of-freedom rigid-body pose estimate.
-                        </p>
+                        <!-- ABSTRACT -->
+                        <div class="abstract">
+                            <p>
+                                Articulated objects pose a unique challenge for robotic perception and manipulation.
+                                Their larger number of degrees-of-freedom makes localization and other tasks more computationaly difficult, while also making the process of real-world dataset collection unscalable.
+                                With the aim of introducing a tool to address these scalability issues, we propose Neural Articulated Radiance Fields (NARF): a pipeline which uses a fully differentiable, configuration parameterized Neural Radiance Field (NeRF) as a means of providing high quality renderings of articulated objects.
+                                NARF requires no explicit knowledge of the object structure at inference time.
+                                We propose a parts-based training mechanism which allows for creating object rendering models that generalize well across the configuration space even if the underlying training data has as few as one configuration represented.
+                                We demonstrate the usefulness of this approach by training configurable renderers on a real-world articulated tool data collected via a Fetch Mobile Manipulator robot.
+                                We then show the applicability of the model to generative or gradient-descent based inference methods by extracting configuration estimates and fine tuning object pose from an initial standard 6 degree-of-freedom rigid-body pose estimate.
+                            </p>
+                        </div>
 
                         <!-- Links. -->
-                        <!-- <p> -->
-                            <!-- <a href="#" class="paperlinks"><i class="far fa-file-pdf"></i> Read the Paper</a> &nbsp;&nbsp; -->
-                            <!-- Optional. -->
-                            <!-- <a href="#" class="paperlinks"><i class="fas fa-chalkboard-teacher"></i> Watch the Talk</a> -->
-                        <!-- </p> -->
+                        <div class="paperlinks">
+                            <p>
+                                <a href="#"><i class="far fa-file-pdf"></i> Read the Paper</a> &nbsp;&nbsp;
+                                <!-- Optional. -->
+                                <a href="#"><i class="fas fa-chalkboard-teacher"></i> Watch the Talk</a>
+                            </p>
+                        </div>
 
                     </article>
 

--- a/projects/progress-labeller/index.html
+++ b/projects/progress-labeller/index.html
@@ -33,18 +33,22 @@
                         <!-- Path to a pitch image. Can be removed if not needed. -->
                         <div class="image centered"><img src="images/progresslabeller_teaser.png" alt="" /></div>
 
-                        <p>
-                            Visual perception tasks often require vast amounts of labelled data, including 3D poses and image space segmentation masks. The process of creating such training data sets can prove difficult or time-intensive to scale up to efficacy for general use. Consider the task of pose estimation for rigid objects. Deep neural network based approaches have shown good performance when trained on large, public datasets. However, adapting these networks for other novel objects, or fine-tuning existing models for different environments, requires significant time investment to generate newly labelled instances. Towards this end, we propose ProgressLabeller as a method for more efficiently generating large amounts of 6D pose training data from color images sequences for custom scenes in a scalable manner. ProgressLabeller is intended to also support transparent or translucent objects, for which the previous methods based on depth dense reconstruction will fail. 
-                            We demonstrate the effectiveness of ProgressLabeller by rapidly create a dataset of over 1M samples with which we fine-tune a state-of-the-art pose estimation network in order to markedly improve the downstream robotic grasp success rates.
-ProgressLabeller will be made publicly available soon.
-                        </p>
+                        <div class="abstract wide">
+                            <p>
+                                Visual perception tasks often require vast amounts of labelled data, including 3D poses and image space segmentation masks. The process of creating such training data sets can prove difficult or time-intensive to scale up to efficacy for general use. Consider the task of pose estimation for rigid objects. Deep neural network based approaches have shown good performance when trained on large, public datasets. However, adapting these networks for other novel objects, or fine-tuning existing models for different environments, requires significant time investment to generate newly labelled instances. Towards this end, we propose ProgressLabeller as a method for more efficiently generating large amounts of 6D pose training data from color images sequences for custom scenes in a scalable manner. ProgressLabeller is intended to also support transparent or translucent objects, for which the previous methods based on depth dense reconstruction will fail.
+                                We demonstrate the effectiveness of ProgressLabeller by rapidly create a dataset of over 1M samples with which we fine-tune a state-of-the-art pose estimation network in order to markedly improve the downstream robotic grasp success rates.
+    ProgressLabeller will be made publicly available soon.
+                            </p>
+                        </div>
 
                         <!-- Links. -->
-                        <p>
-                            <a href="https://drive.google.com/file/d/10Lo2Ybpluod_D03Ur6ieyn5GGMc7x7Nu/view?usp=sharing" class="paperlinks"><i class="far fa-file-pdf"></i> Paper</a> &nbsp;&nbsp;
-                            <!-- Optional. -->
-                            <a href="#cite" class="paperlinks"><i class="fas fa-quote-right"></i>&nbsp;&nbsp;Cite</a>
-                        </p>
+                        <div class="paperlinks wide">
+                            <p>
+                                <a href="https://drive.google.com/file/d/10Lo2Ybpluod_D03Ur6ieyn5GGMc7x7Nu/view?usp=sharing"><i class="far fa-file-pdf"></i> Paper</a> &nbsp;&nbsp;
+                                <!-- Optional. -->
+                                <a href="#cite"><i class="fas fa-quote-right"></i>&nbsp;&nbsp;Cite</a>
+                            </p>
+                        </div>
 
                     </article>
 
@@ -84,7 +88,7 @@ ProgressLabeller will be made publicly available soon.
                         We repeated grasping on every tolerance for 5 times based on the pose estimates. Overall, the fine-tuning over ProgressLabeller data improves the grasping success rate the most, compared with data generated using LabelFusion and Blenderproc.
 
                         Below is a table cleaning task accomplished by pose-based grasping.
-                        
+
                         <div class="image centered"><img src="images/fetch_table_cleaning.png" alt="" width="75%" height="75%"/></div>
 
                     </article>
@@ -138,7 +142,7 @@ journal={arXiv preprint}
                 <!-- Copyright -->
                 <div id="copyright">
                     <ul class="links">
-                        <li>&copy; 2020. All rights reserved.</li><li>Design: Dopetrope by
+                        <li>&copy; 2022. All rights reserved.</li><li>Design: Dopetrope by
                     <a href="http://twitter.com/ajlkn">AJ</a> for <a href="http://html5up.net/">HTML5 UP</li>
                     </ul>
                 </div>

--- a/projects/tool-parts/index.html
+++ b/projects/tool-parts/index.html
@@ -33,16 +33,19 @@
                         <!-- Path to a pitch image. -->
                         <div class="image pitch centered"><img src="images/pitch_figure.png" alt="" /></div>
 
-                        <p>
-                            Robots working in human environments must be able to perceive and act on challenging objects with articulations, such as a pile of tools. Articulated objects increase the dimensionality of the pose estimation problem, and partial observations under clutter create additional challenges. To address this problem, we present a generative-discriminative parts-based recognition and localization framework for articulated objects in clutter. We formulate the problem of articulated object pose estimation as a Markov Random Field (MRF). Hidden nodes in this MRF express the pose of the parts, and edges express the articulation constraints between parts. Localization is performed within the MRF using an efficient belief propagation method. The method is informed by both part segmentation heatmaps over the observation, provided by a neural network, and the articulation constraints between object parts. Our generative-discriminative approach allows the proposed method to function in cluttered environments by inferring the pose of occluded parts using hypotheses from the visible parts. We demonstrate the efficacy of our methods in a tabletop environment for recognizing and localizing hand tools in uncluttered and cluttered configurations.
-                        </p>
+                        <div class="abstract">
+                            <p>
+                                Robots working in human environments must be able to perceive and act on challenging objects with articulations, such as a pile of tools. Articulated objects increase the dimensionality of the pose estimation problem, and partial observations under clutter create additional challenges. To address this problem, we present a generative-discriminative parts-based recognition and localization framework for articulated objects in clutter. We formulate the problem of articulated object pose estimation as a Markov Random Field (MRF). Hidden nodes in this MRF express the pose of the parts, and edges express the articulation constraints between parts. Localization is performed within the MRF using an efficient belief propagation method. The method is informed by both part segmentation heatmaps over the observation, provided by a neural network, and the articulation constraints between object parts. Our generative-discriminative approach allows the proposed method to function in cluttered environments by inferring the pose of occluded parts using hypotheses from the visible parts. We demonstrate the efficacy of our methods in a tabletop environment for recognizing and localizing hand tools in uncluttered and cluttered configurations.
+                            </p>
+                        </div>
 
                         <!-- Links. -->
-                        <p>
-                            <a href="https://arxiv.org/abs/2008.02881" class="paperlinks"><i class="far fa-file-pdf"></i> Read the Paper</a> &nbsp;&nbsp;
-                            <a href="https://youtu.be/D5mnlvZ3bG4" class="paperlinks"><i class="fas fa-chalkboard-teacher"></i> Watch the Talk</a>
-                        </p>
-
+                        <div class="paperlinks">
+                            <p>
+                                <a href="https://arxiv.org/abs/2008.02881"><i class="far fa-file-pdf"></i> Read the Paper</a> &nbsp;&nbsp;
+                                <a href="https://youtu.be/D5mnlvZ3bG4"><i class="fas fa-chalkboard-teacher"></i> Watch the Talk</a>
+                            </p>
+                        </div>
 
                     </article>
 


### PR DESCRIPTION
- Added `div` elements to wrap the page links and abstract. This automatically selects a narrow format, but the `wide` class can be added for pages which use a wide figure layout.
- Added nicer author formatting with affiliations.
- Updated template with instructions and new formatting.
- Updated abstracts and links on existing pages with new format.